### PR TITLE
Refs #8. ATR_MA_Trend now uses IndicatorLegacy

### DIFF
--- a/Misc/ATR_MA_Trend.mq4
+++ b/Misc/ATR_MA_Trend.mq4
@@ -1,0 +1,43 @@
+/**
+ * @file
+ * Implements strategy's indicator.
+ */
+
+#include <EA31337-classes/IndicatorLegacy.h>
+
+#property indicator_chart_window
+#property indicator_buffers 4
+#property indicator_plots 4
+//+----------------------------------------------+
+//|  Bullish indicator rendering options    |
+//+----------------------------------------------+
+#property indicator_type1 DRAW_LINE
+#property indicator_color1 Blue
+#property indicator_style1 STYLE_DASHDOTDOT
+#property indicator_width1 2
+#property indicator_label1 "Upper TrendValue"
+//+----------------------------------------------+
+//|  Bearish indicator rendering options   |
+//+----------------------------------------------+
+#property indicator_type2 DRAW_LINE
+#property indicator_color2 MediumVioletRed
+#property indicator_style2 STYLE_DASHDOTDOT
+#property indicator_width2 2
+#property indicator_label2 "Lower TrendValue"
+//+----------------------------------------------+
+//|  Bullish indicator rendering options      |
+//+----------------------------------------------+
+#property indicator_type3 DRAW_ARROW
+#property indicator_color3 DeepSkyBlue
+#property indicator_width3 4
+#property indicator_label3 "Buy TrendValue"
+//+----------------------------------------------+
+//|  Bearish indicator rendering options  |
+//+----------------------------------------------+
+#property indicator_type4 DRAW_ARROW
+#property indicator_color4 Red
+#property indicator_width4 4
+#property indicator_label4 "Sell TrendValue"
+
+// Includes the main file.
+#include "ATR_MA_Trend.mq5"

--- a/Misc/ATR_MA_Trend.mq4.todo
+++ b/Misc/ATR_MA_Trend.mq4.todo
@@ -1,7 +1,0 @@
-/**
- * @file
- * Implements strategy's indicator.
- */
-
-// Includes the main file.
-#include "ATR_MA_Trend.mq5"


### PR DESCRIPTION
Allows using MQL5 versions of iNAME() indicators like iMA(), iRSI() in MQL4. We use it to run MQL5 indicator in MQL4.
Fixes GH-8.